### PR TITLE
chore: readme update and snapshot version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # fonix-client
+JVM client for the [Fonix](https://www.fonix.com/documentation) integration
 
-Usage: 
 
+## Usage: 
+### Maven:
 ```xml
 <dependency>
     <groupId>com.lindar</groupId>
     <artifactId>fonix-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.6.0</version>
 </dependency>
+```
+### Gradle:
+```kotlin
+implementation("com.lindar:fonix-client:1.6.0")
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lindar</groupId>
     <artifactId>fonix-client</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.1-SNAPSHOT</version>
 
     <name>Fonix Java Client</name>
     <description>A java client for Fonix</description>


### PR DESCRIPTION
**What's changed**
- readme update
- bumped snapshot version of dev to next one (1.6.0 has been released already)